### PR TITLE
Added support for Visual Studio 2019

### DIFF
--- a/src/VSIX/source.extension.vsixmanifest
+++ b/src/VSIX/source.extension.vsixmanifest
@@ -13,17 +13,16 @@
     </Metadata>
     <Installation>
         <InstallationTarget Id="Microsoft.VisualStudio.IntegratedShell" Version="[11.0,15.0)" />
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0]" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0,17.0)" />
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-        <Dependency d:Source="Installed" Id="Microsoft.VisualStudio.MPF.11.0" DisplayName="Visual Studio MPF 11.0" Version="[11.0,12.0)" />
     </Dependencies>
     <Assets>
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="ColumnGuidePackage" Path="|ColumnGuidePackage;PkgdefProjectOutputGroup|" />
         <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="ColumnGuide" Path="|ColumnGuide|" />
     </Assets>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
     </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
I've updated the version ranges and removed an old unneeded dependency on MPF. That should be all needed for VS 2019 support