### PR TITLE
Remove the Preview designation from the VS 2022 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Editor Guidelines
 All notable changes will be documented in this file.
 
+## Version [2.2.8] (Nov 15th 2021)
+### Changed
+- Removed the Preview tag from the VS 2022 version.
+
 ## Version [2.2.7] (June 21st 2021)
 ### Fixed
 - Fixed issue [#82](https://github.com/pharring/EditorGuidelines/issues/82) where version 2.2.6 wouldn't load in VS 2015 and VS 2017.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <Company>Paul Harrington</Company>
     <Copyright>Copyright © 2021 Paul Harrington</Copyright>
-    <Version>2.2.7</Version>
+    <Version>2.2.8</Version>
     <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnlistmentRoot>$(MSBuildThisFileDirectory)</EnlistmentRoot>

--- a/src/VSIX_Dev17/source.extension.vsixmanifest
+++ b/src/VSIX_Dev17/source.extension.vsixmanifest
@@ -3,15 +3,14 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="EditorGuidelines.f7dfa085-35e4-4844-8842-48298d5eaee0" Version="|%CurrentProject%;GetPackageVersion|" Language="en-US" Publisher="Paul Harrington" />
-    <DisplayName>Editor Guidelines (Preview)</DisplayName>
+    <DisplayName>Editor Guidelines</DisplayName>
     <Description xml:space="preserve">Adds vertical column guides to the Visual Studio text editor.</Description>
     <MoreInfo>https://marketplace.visualstudio.com/items?itemName=PaulHarrington.EditorGuidelines</MoreInfo>
     <License>LICENSE</License>
     <GettingStartedGuide>https://github.com/pharring/EditorGuidelines#getting-started</GettingStartedGuide>
     <ReleaseNotes>https://github.com/pharring/EditorGuidelines/blob/master/CHANGELOG.md</ReleaseNotes>
     <Icon>EditorGuidelines_128px.png</Icon>
-    <Tags>Preview;Editor;Editing;Guidelines;Column</Tags>
-    <Preview>true</Preview>
+    <Tags>Editor;Editing;Guidelines;Column</Tags>
   </Metadata>
   <Installation>
     <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, 18.0)">


### PR DESCRIPTION
Fixes #89 