### PR TITLE
Stop including CodingConventions DLL in VSIX

### DIFF
--- a/src/ColumnGuide/Properties/AssemblyInfo.cs
+++ b/src/ColumnGuide/Properties/AssemblyInfo.cs
@@ -3,7 +3,6 @@
 using Microsoft.VisualStudio.Shell;
 using System;
 using System.Reflection;
-using System.Resources;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -16,6 +15,9 @@ using System.Runtime.InteropServices;
 [assembly: CLSCompliant(false)]
 
 [assembly: ProvideCodeBase(CodeBase = "Microsoft.ApplicationInsights.dll")]
+#if !Dev17
+// Include CodingConventions prior to VS 2022
 [assembly: ProvideCodeBase(CodeBase = "Microsoft.VisualStudio.CodingConventions.dll")]
+#endif
 
 [assembly: InternalsVisibleTo("ColumnGuideTests")]

--- a/src/VSIX/VSIX.csproj
+++ b/src/VSIX/VSIX.csproj
@@ -69,7 +69,7 @@
 
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
 
-  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VsSDKInstall)\Microsoft.VsSDK.targets" Condition="'$(VsSDKInstall)' != ''" />
 
   <Target Name="IncludeNuGetPackageReferences" AfterTargets="GetVsixSourceItems">
     <ItemGroup>

--- a/src/VSIX_Dev17/VSIX_Dev17.csproj
+++ b/src/VSIX_Dev17/VSIX_Dev17.csproj
@@ -42,10 +42,10 @@
     <!-- Microsoft.VisualStudio.CodingConventions will be loaded from Common7\IDE\PublicAssemblies
          at runtime, so we don't need to include it in the VSIX. -->
     <PackageReference Include="Microsoft.VisualStudio.CodingConventions" Version="1.1.20180503.2" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.0-previews-1-31410-273" ExcludeAssets="runtime">
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.32112.339" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.4.2119">
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.5.4072">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -75,7 +75,7 @@
 
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
 
-  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VsSDKInstall)\Microsoft.VsSDK.targets" Condition="'$(VsSDKInstall)' != ''" />
 
   <Target Name="IncludeNuGetPackageReferences" AfterTargets="GetVsixSourceItems">
     <ItemGroup>

--- a/src/VSIX_Dev17/VSIX_Dev17.csproj
+++ b/src/VSIX_Dev17/VSIX_Dev17.csproj
@@ -8,6 +8,7 @@
     <RootNamespace>EditorGuidelines</RootNamespace>
     <AssemblyName>EditorGuidelines</AssemblyName>
     <NeutralLanguage>en-US</NeutralLanguage>
+    <DefineConstants>Dev17</DefineConstants>
 
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
     <UseCodebase>true</UseCodebase>
@@ -31,13 +32,16 @@
   <ItemGroup>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Design" />
     <Reference Include="WindowsBase" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.1.0" />
-    <PackageReference Include="Microsoft.VisualStudio.CodingConventions" Version="1.1.20180503.2" />
+    <!-- Microsoft.VisualStudio.CodingConventions will be loaded from Common7\IDE\PublicAssemblies
+         at runtime, so we don't need to include it in the VSIX. -->
+    <PackageReference Include="Microsoft.VisualStudio.CodingConventions" Version="1.1.20180503.2" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.0-previews-1-31410-273" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -77,7 +81,6 @@
     <ItemGroup>
       <_ReferenceCopyLocalBinaries Include="@(ReferenceCopyLocalPaths)" Condition="'%(Extension)' != '.pdb'" />
       <VSIXSourceItem Include="@(_ReferenceCopyLocalBinaries)" Condition="'%(_ReferenceCopyLocalBinaries.NuGetPackageId)' == 'Microsoft.ApplicationInsights'" />
-      <VSIXSourceItem Include="@(_ReferenceCopyLocalBinaries)" Condition="'%(_ReferenceCopyLocalBinaries.NuGetPackageId)' == 'Microsoft.VisualStudio.CodingConventions'" />
     </ItemGroup>
   </Target>
 

--- a/src/VSIX_Dev17/source.extension.vsixmanifest
+++ b/src/VSIX_Dev17/source.extension.vsixmanifest
@@ -22,6 +22,7 @@
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+    <Dependency d:Source="Installed" Id="Microsoft.VisualStudio.CodingConventions" DisplayName="Microsoft Visual Studio CodingConventions" Version="[10.0,)" />
   </Dependencies>
   <Assets>
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />


### PR DESCRIPTION
Fixes #116

The problem here was that we were including a version of Microsoft.VisualStudio.CodingConventions.dll in the VSIX and referencing it with a ProvideCodeBase directive (in AssemblyInfo.cs)
However, there's a newer version in PublicAssemblies and that's used by the Spell Checker component.

The fix is to stop including it in the VSIX and to let it load from PublicAssemblies at runtime. In order to prevent type resolution failures for installations that don't have CodingConventions, I added a VSIX dependency on Microsoft.VisualStudio.CodingConventions. I don't have access to Visual Studio versions prior to 17.5, so I can't check whether this is available all the way back to 17.0.