### PR TITLE
Fix CodingConventions support in 17.10

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,0 @@
-{
-  "sdk": {
-    "version": "7.0.100",
-    "rollForward": "feature"
-  }
-}

--- a/src/ColumnGuide/ColumnGuideFactory.cs
+++ b/src/ColumnGuide/ColumnGuideFactory.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Paul Harrington.  All Rights Reserved.  Licensed under the MIT License.  See LICENSE in the project root for license information.
 
 using Microsoft.ApplicationInsights.DataContracts;
-using Microsoft.VisualStudio.CodingConventions;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Utilities;
 using System.Collections.Generic;
@@ -42,7 +41,7 @@ namespace EditorGuidelines
         {
             // Always create the adornment, even if there are no guidelines, since we
             // respond to dynamic changes.
-            var _ = new ColumnGuideAdornment(textView, TextEditorGuidesSettings, GuidelineBrush, CodingConventionsManager);
+            var _ = new ColumnGuideAdornment(textView, TextEditorGuidesSettings, GuidelineBrush, CodingConventions);
         }
 
         public void OnImportsSatisfied()
@@ -120,11 +119,11 @@ namespace EditorGuidelines
         [Import]
         private GuidelineBrush GuidelineBrush { get; set; }
 
-        [Import(AllowDefault = true)]
-        private ICodingConventionsManager CodingConventionsManager { get; set; }
+        [Import]
+        private CodingConventions CodingConventions { get; set; }
 
         [Import]
         private HostServices HostServices { get; set; }
     }
-    #endregion //Adornment Factory
+#endregion //Adornment Factory
 }

--- a/src/VSIX/CodingConventions.cs
+++ b/src/VSIX/CodingConventions.cs
@@ -14,6 +14,9 @@ namespace EditorGuidelines
     [Export]
     internal class CodingConventions
     {
+        /// <summary>
+        /// Try to import from Microsoft.VisualStudio.CodingConventions.
+        /// </summary>
         [Import(AllowDefault = true)]
         private ICodingConventionsManager CodingConventionsManager { get; set; }
 

--- a/src/VSIX/CodingConventions.cs
+++ b/src/VSIX/CodingConventions.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) Paul Harrington.  All Rights Reserved.  Licensed under the MIT License.  See LICENSE in the project root for license information.
+
+using System.ComponentModel.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.CodingConventions;
+using Microsoft.VisualStudio.Text.Editor;
+
+namespace EditorGuidelines
+{
+    /// <summary>
+    /// Coding conventions support via Microsoft.VisualStudio.CodingConventions assembly.
+    /// </summary>
+    [Export]
+    internal class CodingConventions
+    {
+        [Import(AllowDefault = true)]
+        private ICodingConventionsManager CodingConventionsManager { get; set; }
+
+        public async Task<Context> CreateContextAsync(IWpfTextView view, CancellationToken cancellationToken)
+        {
+            if (CodingConventionsManager is null)
+            {
+                // Coding Conventions not available in this SKU.
+                return null;
+            }
+
+            if (!view.TryGetTextDocument(out var textDocument))
+            {
+                return null;
+            }
+
+            string filePath = textDocument.FilePath;
+            ICodingConventionContext codingConventionContext = await CodingConventionsManager.GetConventionContextAsync(filePath, cancellationToken).ConfigureAwait(false);
+            return new Context(codingConventionContext, cancellationToken);
+        }
+
+        /// <summary>
+        /// Coding conventions narrowed to a single file.
+        /// </summary>
+        public class Context
+        {
+            private readonly ICodingConventionContext _innerContext;
+
+            public Context(ICodingConventionContext innerContext, CancellationToken cancellationToken)
+            {
+                _innerContext = innerContext;
+                _innerContext.CodingConventionsChangedAsync += OnCodingConventionsChangedAsync;
+                cancellationToken.Register(() => _innerContext.CodingConventionsChangedAsync -= OnCodingConventionsChangedAsync);
+            }
+
+            private Task OnCodingConventionsChangedAsync(object sender, CodingConventionsChangedEventArgs arg)
+            {
+                ConventionsChanged?.Invoke(this);
+                return Task.CompletedTask;
+            }
+
+            public delegate void ConventionsChangedEventHandler(Context sender);
+            
+            public event ConventionsChangedEventHandler ConventionsChanged;
+
+            public bool TryGetCurrentSetting(string key, out string value)
+            {
+                return _innerContext.CurrentConventions.TryGetConventionValue(key, out value);
+            }
+        }
+    }
+}

--- a/src/VSIX/CodingConventions.cs
+++ b/src/VSIX/CodingConventions.cs
@@ -12,7 +12,7 @@ namespace EditorGuidelines
     /// Coding conventions support via Microsoft.VisualStudio.CodingConventions assembly.
     /// </summary>
     [Export]
-    internal class CodingConventions
+    internal sealed class CodingConventions
     {
         /// <summary>
         /// Try to import from Microsoft.VisualStudio.CodingConventions.

--- a/src/VSIX_Dev17/CodingConventions.cs
+++ b/src/VSIX_Dev17/CodingConventions.cs
@@ -1,4 +1,6 @@
-﻿using System.ComponentModel.Composition;
+﻿// Copyright (c) Paul Harrington.  All Rights Reserved.  Licensed under the MIT License.  See LICENSE in the project root for license information.
+
+using System.ComponentModel.Composition;
 using System.Threading.Tasks;
 using System.Threading;
 using Microsoft.VisualStudio.Text.Editor;
@@ -26,6 +28,12 @@ namespace EditorGuidelines
             private readonly CancellationToken _cancellationToken;
             private IReadOnlyDictionary<string, object> _currentConventions;
 
+            // This is the same as DefaultOptions.RawCodingConventionsSnapshotOptionName from the 17.6
+            // editor SDK. However, by not referencing that constant, we can avoid taking a dependency
+            // on the 17.6 SDK and can continue to load on earlier versions (albeit without
+            // CodingConventions support).
+            private const string c_codingConventionsSnapshotOptionName = "CodingConventionsSnapshot";
+
             public Context(IEditorOptions editorOptions, CancellationToken cancellationToken)
             {
                 _editorOptions = editorOptions;
@@ -37,9 +45,9 @@ namespace EditorGuidelines
 
             private void OnEditorOptionChanged(object sender, EditorOptionChangedEventArgs e)
             {
-                if (e.OptionId == DefaultOptions.RawCodingConventionsSnapshotOptionName)
+                if (e.OptionId == c_codingConventionsSnapshotOptionName)
                 {
-                    _currentConventions = _editorOptions.GetOptionValue(DefaultOptions.RawCodingConventionsSnapshotOptionId);
+                    _currentConventions = _editorOptions.GetOptionValue<IReadOnlyDictionary<string, object>>(c_codingConventionsSnapshotOptionName);
                     ConventionsChanged?.Invoke(this);
                 }
             }
@@ -51,7 +59,7 @@ namespace EditorGuidelines
             public bool TryGetCurrentSetting(string key, out string value)
             {
                 if (_currentConventions is null || !_currentConventions.TryGetValue(key, out object obj) || obj is null)
-                { 
+                {
                     value = null;
                     return false;
                 }
@@ -60,6 +68,5 @@ namespace EditorGuidelines
                 return !string.IsNullOrEmpty(value);
             }
         }
-
     }
 }

--- a/src/VSIX_Dev17/CodingConventions.cs
+++ b/src/VSIX_Dev17/CodingConventions.cs
@@ -1,0 +1,65 @@
+﻿using System.ComponentModel.Composition;
+using System.Threading.Tasks;
+using System.Threading;
+using Microsoft.VisualStudio.Text.Editor;
+using System.Collections.Generic;
+
+namespace EditorGuidelines
+{
+    /// <summary>
+    /// Dev 17 support for Coding Conventions. Uses the dictionary supplied via <see cref="IEditorOptions"/>.
+    /// </summary>
+    [Export]
+    internal sealed class CodingConventions
+    {
+        public Task<Context> CreateContextAsync(IWpfTextView view, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new Context(view.Options, cancellationToken));
+        }
+
+        /// <summary>
+        /// Coding conventions narrowed to a single file.
+        /// </summary>
+        public class Context
+        {
+            private readonly IEditorOptions _editorOptions;
+            private readonly CancellationToken _cancellationToken;
+            private IReadOnlyDictionary<string, object> _currentConventions;
+
+            public Context(IEditorOptions editorOptions, CancellationToken cancellationToken)
+            {
+                _editorOptions = editorOptions;
+                _cancellationToken = cancellationToken;
+
+                _editorOptions.OptionChanged += OnEditorOptionChanged;
+                _cancellationToken.Register(() => _editorOptions.OptionChanged -= OnEditorOptionChanged);
+            }
+
+            private void OnEditorOptionChanged(object sender, EditorOptionChangedEventArgs e)
+            {
+                if (e.OptionId == DefaultOptions.RawCodingConventionsSnapshotOptionName)
+                {
+                    _currentConventions = _editorOptions.GetOptionValue(DefaultOptions.RawCodingConventionsSnapshotOptionId);
+                    ConventionsChanged?.Invoke(this);
+                }
+            }
+
+            public delegate void ConventionsChangedEventHandler(Context sender);
+
+            public event ConventionsChangedEventHandler ConventionsChanged;
+
+            public bool TryGetCurrentSetting(string key, out string value)
+            {
+                if (_currentConventions is null || !_currentConventions.TryGetValue(key, out object obj) || obj is null)
+                { 
+                    value = null;
+                    return false;
+                }
+
+                value = obj.ToString();
+                return !string.IsNullOrEmpty(value);
+            }
+        }
+
+    }
+}

--- a/src/VSIX_Dev17/VSIX_Dev17.csproj
+++ b/src/VSIX_Dev17/VSIX_Dev17.csproj
@@ -39,7 +39,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.1.0" />
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.6.36389" ExcludeAssets="runtime">
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.32112.339" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.8.2365">

--- a/src/VSIX_Dev17/VSIX_Dev17.csproj
+++ b/src/VSIX_Dev17/VSIX_Dev17.csproj
@@ -39,13 +39,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.1.0" />
-    <!-- Microsoft.VisualStudio.CodingConventions will be loaded from Common7\IDE\PublicAssemblies
-         at runtime, so we don't need to include it in the VSIX. -->
-    <PackageReference Include="Microsoft.VisualStudio.CodingConventions" Version="1.1.20180503.2" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.32112.339" ExcludeAssets="runtime">
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.6.36389" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.5.4072">
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.8.2365">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
This PR changes the way we read Coding Conventions (from .editorconfig) for Dev 17.
We were previously using the Microsoft.VisualStudio.CodingConventions NuGet and assuming that the implementation assembly is installed with Visual Studio. However, that assembly has been removed in 17.10 preview 1 and we need to come up with an alternative.
I split the implementations between Dev 17 and previous versions (Dev 15 and Dev 16) by introducing my own CodingConventions helper class. Each VSIX has its own implementation. The down-level version just re-implements the existing code.
The new, Dev17 implementation, uses IEditorOptions to fetch the "CodingConventionsSnapshot" dictionary containing .editorconfig settings.

The CodingConventionsSnapshot was introduced in version 17.6 of Visual Studio 2022. I haven't changed the minimum install version of this extension, though. So, technically, the extension will install on, say 17.5, but .editorconfig support will be lacking.