### PR TITLE
Remove the Myget feed from nuget.config

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -2,6 +2,5 @@
 <configuration>
   <packageSources>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="vs-editor" value="https://myget.org/F/vs-editor/api/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
The Myget.org feed is no longer needed.