### PR TITLE
Ensure that the Text Editor settings collection exists before we try to write to it

### DIFF
--- a/src/ColumnGuide/TextEditorGuidesSettings.cs
+++ b/src/ColumnGuide/TextEditorGuidesSettings.cs
@@ -55,6 +55,13 @@ namespace EditorGuidelines
         private void WriteUserSettingsString(string key, string propertyName, string value)
         {
             var store = ReadWriteUserSettings;
+
+            Marshal.ThrowExceptionForHR(store.CollectionExists(key, out int exists));
+            if (exists == 0)
+            {
+                Marshal.ThrowExceptionForHR(store.CreateCollection(key));
+            }
+
             Marshal.ThrowExceptionForHR(store.SetString(key, propertyName, value));
         }
 


### PR DESCRIPTION
#### PR Classification
Bug fix: Improved error handling and ensured proper initialization of settings collections.

#### PR Summary
Discovered when testing with Visual Studio 2026 which, it turns out, does not have a "Text Editor" collection in the user settings store.
This pull request enhances the robustness of the `WriteUserSettingsString` method by adding error handling and ensuring the existence of settings collections before writing to them.
- **TextEditorGuidesSettings.cs**: Added checks for collection existence using `store.CollectionExists` and created the collection if it does not exist. Wrapped operations with `Marshal.ThrowExceptionForHR` for better error handling.
